### PR TITLE
🩹 fix(lock): 락이 걸린 메서드에서 exception 발생 시 lock 해제 오류 수정

### DIFF
--- a/src/main/java/com/junwoo/ott/domain/coupon/service/CouponLockService.java
+++ b/src/main/java/com/junwoo/ott/domain/coupon/service/CouponLockService.java
@@ -12,7 +12,7 @@ public class CouponLockService {
 
   private final CouponService couponService;
 
-  @Lockable(value = "createCouponIssuance Lock", waitTime = 50, leaseTime = 50, timeUnit = TimeUnit.SECONDS)
+  @Lockable(value = "createCouponIssuance Lock", waitTime = 5, leaseTime = 3, timeUnit = TimeUnit.SECONDS)
   public void createCouponIssuanceLock(final CouponIssuanceCreateRequestDto createRequestDto) {
     couponService.createCouponIssuance(createRequestDto);
   }

--- a/src/main/java/com/junwoo/ott/global/aop/LockAspect.java
+++ b/src/main/java/com/junwoo/ott/global/aop/LockAspect.java
@@ -47,6 +47,17 @@ public class LockAspect {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new CustomLockException("Interrupt 발생");
+    } catch (RuntimeException e) {
+
+      if (lock.isHeldByCurrentThread()) { // 락이 현재 내 스레드 일 때만 해제를 한다.
+        log.info("현재 내 스레드에서 예외가 발생해서 Lock을 해제");
+        lock.unlock();
+      } else {
+        log.info("남의 스레드에서 Lock이 가지고 있는 상태임..");
+        log.info("개빡침 그냥 안함");
+      }
+
+      throw e;
     }
   }
 


### PR DESCRIPTION
## 변경사항

- 락이 걸린 메서드에서 exception 발생 시 lock 해제 오류 수정
- 해당 exception을 락 쪽에서 RuntimeException으로 잡은 뒤에 lock을 해제하는 식으로 진행
- 또한 현재 락의 wait_time 과 lease_time에 대한 시간을 설정 각각 5초, 3초

### 변경의 종류 (여러 가지 선택 가능)

- [ ] 새로운 기능
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 테스트 추가
- [x] 기타(설명 추가)

---

## 체크리스트

- [x] ERD설계와 API설계를 잘 적용하여 개발하였는가?
- [x] 서비스 테스트의 커버리지가 80% 이상인가?
- [x] 코딩 컨벤션을 준수하였는가?
- [x] 예외 처리가 잘 되어 있는가?
- [x] 커밋 메시지를 컨벤션에 맞게 작성 하였는가?